### PR TITLE
Fix invalid config path

### DIFF
--- a/src/Helper/ConfigHelper.php
+++ b/src/Helper/ConfigHelper.php
@@ -19,7 +19,7 @@ class ConfigHelper
     {
         $this->entityManager = $entityManager;
         $this->fileSystem = $fileSystem;
-        $this->environmentConfigFilePath = realpath($projectDirectory . '/config/env.mosparo.php');
+        $this->environmentConfigFilePath = $projectDirectory . '/config/env.mosparo.php';
     }
 
     public function getEnvironmentConfigValue($name, $defaultValue = false)


### PR DESCRIPTION
The [`realpath`](https://www.php.net/manual/en/function.realpath.php) function will return false when it fails eg : file does not exist.

In this case the file `/config/env.mosparo.php` is not yet available so `realpath` will return `false` and cause failure to write database configuration to config file during installation process

![Screenshot from 2023-01-17 03-48-03](https://user-images.githubusercontent.com/37969970/212757001-464bf37e-36b9-4ac6-9419-7fe4c408fbab.png)
![Screenshot from 2023-01-17 03-48-59](https://user-images.githubusercontent.com/37969970/212757004-64e121db-01a4-4d40-89ab-a30aac55ac13.png)
![Screenshot from 2023-01-17 03-49-36](https://user-images.githubusercontent.com/37969970/212757006-a61aee6c-faab-4126-894c-bb5116bd1234.png)
