### PR TITLE
Session handling for support multi-server setups

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -12,7 +12,7 @@ framework:
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:
-        handler_id: null
+        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
         cookie_secure: auto
         cookie_samesite: lax
         storage_factory_id: session.storage.factory.native

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -65,6 +65,11 @@ services:
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 
+    Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
+        arguments:
+            - !service { class: PDO, factory: [ '@database_connection', 'getWrappedConnection' ] }
+            - { lock_mode: 0 }
+
     Mosparo\Subscriber\ApiSubscriber:
         class: Mosparo\Subscriber\ApiSubscriber
         tags:

--- a/migrations/Version20230331111545.php
+++ b/migrations/Version20230331111545.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230331111545 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE sessions (sess_id VARBINARY(128) NOT NULL PRIMARY KEY,sess_data BLOB NOT NULL,sess_lifetime INTEGER UNSIGNED NOT NULL,sess_time INTEGER UNSIGNED NOT NULL,INDEX sessions_sess_lifetime_idx (sess_lifetime)) COLLATE utf8mb4_bin, ENGINE = InnoDB;');
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE sessions;');
+    }
+}


### PR DESCRIPTION
Hi,

i noticed that Mosparo uses the default Symfony sessions handling, which does not work when the application is served from multiple servers.

Symfony Session Dokumentation: [Symfony stores sessions in files by default. If your application is served by multiple servers, you'll need to use a database instead to make sessions work across different servers.](https://symfony.com/doc/5.4/session.html#store-sessions-in-a-database)
