### PR TITLE
Add callback for the ResetState function

### DIFF
--- a/assets/mosparo-frontend.js
+++ b/assets/mosparo-frontend.js
@@ -17,7 +17,8 @@ function mosparo(containerId, url, uuid, publicKey, options)
         requestSubmitTokenOnInit: true,
 
         // Callbacks
-        onCheckForm: null
+        onCheckForm: null,
+        onResetState: null
     };
     this.options = {...this.defaultOptions, ...options};
 
@@ -436,6 +437,10 @@ function mosparo(containerId, url, uuid, publicKey, options)
         }
 
         _this.formElement.dispatchEvent(new CustomEvent('state-reset'));
+
+        if (_this.options.onResetState !== null) {
+            _this.options.onResetState();
+        }
     }
 
     this.send = function (endpoint, data, callbackSuccess, callbackError) {


### PR DESCRIPTION
Hi,
if I create a form where I want the submit button to remain disabled as long as the Mosparo captcha is not valid. 
To do this, I would need to be able to disable the submit button again when the resetState function is called.
Which is not possible without a callback for the function „resetState“.