### PR TITLE
Fix handling return character in ip allow list 

### DIFF
--- a/src/Helper/SecurityHelper.php
+++ b/src/Helper/SecurityHelper.php
@@ -56,13 +56,17 @@ class SecurityHelper
 
     protected function isIpOnAllowList($ipAddress, $ipAllowList): bool
     {
-        $items = explode(PHP_EOL, $ipAllowList);
+        $items = preg_split('/\r\n|\r|\n/', $ipAllowList);
         foreach ($items as $item) {
             if (strpos($item, '/') !== false) {
                 $address = Factory::parseAddressString($ipAddress);
                 $subnet = Subnet::parseString($item);
 
-                if ($address->getAddressType() == $subnet->getAddressType() && $subnet->contains($address)) {
+                if ($address !== null &&
+                    $subnet !== null &&
+                    $address->getAddressType() == $subnet->getAddressType() &&
+                    $subnet->contains($address)
+                ) {
                     return true;
                 }
             } else if ($item === $ipAddress) {


### PR DESCRIPTION
Hello, 
while testing the option "IP allow list".
I noticed that if there are one or more "return character (\r)" in the string, it comes to errors in "SecurityHelper->isIpOnAllowList".
This leads to the fact that Captcha cannot be loaded in the form.
In order to fix this I have replaced `explode(PHP_EOL, $ipAllowList)` with `preg_split('/\r\n|\r|\n/', $ipAllowList)`
replaced. 
See explanation why: [https://stackoverflow.com/a/29471912](https://stackoverflow.com/a/29471912)

Additionally it was not considered that `Factory::parseAddressString` and `Subnet::parseString` can return a "null" value.

My initial error: 
```
Uncaught Error: Call to a member function getAddressType() on null {"exception":"[object] (Error(code: 0): Call to a member function getAddressType() on null at /var/www/htdocs/src/Helper/SecurityHelper.php:71)"} []
```