### PR TITLE
Missing attribute "autocomplete"  on password field

### DIFF
--- a/src/Controller/Account/AccountController.php
+++ b/src/Controller/Account/AccountController.php
@@ -115,7 +115,7 @@ class AccountController extends AbstractController
     public function changePassword(Request $request, EntityManagerInterface $entityManager): Response
     {
         $form = $this->createFormBuilder([], ['translation_domain' => 'mosparo'])
-            ->add('oldPassword', PasswordType::class, ['label' => 'account.changePassword.form.oldPassword', 'constraints' => [new UserPassword()]])
+            ->add('oldPassword', PasswordType::class, ['label' => 'account.changePassword.form.oldPassword', 'constraints' => [new UserPassword()], 'attr' => ['autocomplete' => 'off']])
             ->add('newPassword', PasswordFormType::class, [
                 'mapped' => false,
                 'is_new_password' => true,

--- a/src/Controller/Administration/SettingsController.php
+++ b/src/Controller/Administration/SettingsController.php
@@ -66,7 +66,7 @@ class SettingsController extends AbstractController
             ->add('mailerHost', TextType::class, ['label' => 'administration.settings.mailSettings.form.host', 'attr' => ['disabled' => true, 'class' => 'mail-option']])
             ->add('mailerPort', TextType::class, ['label' => 'administration.settings.mailSettings.form.port', 'attr' => ['disabled' => true, 'class' => 'mail-option']])
             ->add('mailerUser', TextType::class, ['label' => 'administration.settings.mailSettings.form.user', 'required' => false, 'attr' => ['disabled' => true, 'class' => 'mail-option']])
-            ->add('mailerPassword', PasswordType::class, ['label' => 'administration.settings.mailSettings.form.password', 'help' => 'administration.settings.mailSettings.help.password', 'required' => false, 'attr' => ['disabled' => true, 'class' => 'mail-option']])
+            ->add('mailerPassword', PasswordType::class, ['label' => 'administration.settings.mailSettings.form.password', 'help' => 'administration.settings.mailSettings.help.password', 'required' => false, 'attr' => ['disabled' => true, 'class' => 'mail-option', 'autocomplete' => 'off']])
             ->add('mailerFromAddress', EmailType::class, ['label' => 'administration.settings.mailSettings.form.fromAddress', 'required' => false])
             ->add('mailerFromName', TextType::class, ['label' => 'administration.settings.mailSettings.form.fromName', 'required' => false])
             ->getForm();


### PR DESCRIPTION
We have run a small security test against the Mosparo backend.
The only result was that no "autocomplete='off'" is set for password fields.