### PR TITLE
Fix the CleanupHelper

### DIFF
--- a/migrations/Version20230622174506.php
+++ b/migrations/Version20230622174506.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230622174506 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE submit_token DROP FOREIGN KEY FK_6C047AC8E1FD4933');
+        $this->addSql('DROP INDEX UNIQ_6C047AC8E1FD4933 ON submit_token');
+        $this->addSql('ALTER TABLE submit_token CHANGE submission_id valid_submission_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE submit_token ADD CONSTRAINT FK_6C047AC86210F1A7 FOREIGN KEY (valid_submission_id) REFERENCES submission (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_6C047AC86210F1A7 ON submit_token (valid_submission_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE submit_token DROP FOREIGN KEY FK_6C047AC86210F1A7');
+        $this->addSql('DROP INDEX UNIQ_6C047AC86210F1A7 ON submit_token');
+        $this->addSql('ALTER TABLE submit_token CHANGE valid_submission_id submission_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE submit_token ADD CONSTRAINT FK_6C047AC8E1FD4933 FOREIGN KEY (submission_id) REFERENCES submission (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_6C047AC8E1FD4933 ON submit_token (submission_id)');
+    }
+}

--- a/src/Controller/Api/V1/Verification/VerificationApiController.php
+++ b/src/Controller/Api/V1/Verification/VerificationApiController.php
@@ -56,7 +56,7 @@ class VerificationApiController extends AbstractController
             return new JsonResponse(['error' => true, 'errorMessage' => 'Submit token not found or not valid.']);
         }
 
-        $submission = $submitToken->getSubmission();
+        $submission = $submitToken->getValidSubmission();
         if (!$submission) {
             return new JsonResponse(['error' => true, 'errorMessage' => 'Submission does not exist.']);
         }

--- a/src/Entity/Submission.php
+++ b/src/Entity/Submission.php
@@ -112,13 +112,13 @@ class Submission implements ProjectRelatedEntityInterface
     public function setSubmitToken(?SubmitToken $submitToken): self
     {
         // unset the owning side of the relation if necessary
-        if ($submitToken === null && $this->submitToken !== null && $this->submitToken->getSubmission() === $this) {
-            $this->submitToken->setSubmission(null);
+        if ($submitToken === null && $this->submitToken !== null && $this->submitToken->getValidSubmission() === $this) {
+            $this->submitToken->setValidSubmission(null);
         }
 
         // set the owning side of the relation if necessary
-        if ($submitToken !== null && $submitToken->getSubmission() !== $this) {
-            $submitToken->setSubmission($this);
+        if ($submitToken !== null && $submitToken->getValidSubmission() !== $this) {
+            $submitToken->setValidSubmission($this);
         }
 
         $this->submitToken = $submitToken;

--- a/src/Entity/SubmitToken.php
+++ b/src/Entity/SubmitToken.php
@@ -67,7 +67,7 @@ class SubmitToken implements ProjectRelatedEntityInterface
     /**
      * @ORM\OneToOne(targetEntity=Submission::class)
      */
-    private ?Submission $submission;
+    private ?Submission $validSubmission;
 
     /**
      * @ORM\ManyToOne(targetEntity=Project::class)
@@ -188,14 +188,14 @@ class SubmitToken implements ProjectRelatedEntityInterface
         return $this;
     }
 
-    public function getSubmission(): ?Submission
+    public function getValidSubmission(): ?Submission
     {
-        return $this->submission;
+        return $this->validSubmission;
     }
 
-    public function setSubmission(?Submission $submission): self
+    public function setValidSubmission(?Submission $validSubmission): self
     {
-        $this->submission = $submission;
+        $this->validSubmission = $validSubmission;
 
         return $this;
     }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -9,7 +9,7 @@ class Kernel extends BaseKernel
 {
     const MAJOR_VERSION = '0.4';
 
-    const VERSION = '0.4.0';
+    const VERSION = '0.4.1';
 
     use MicroKernelTrait;
 }


### PR DESCRIPTION
The CleanupHelper tried to delete the submit tokens after 24 hours if the valid submission was not verified, and before all invalid submissions were correctly deleted.

This fix solves this issue by checking which submit tokens are still referenced by submissions. Only after all submissions for a submit token were deleted, the submit token can be deleted too.

See #97 

Additionally, the naming of the property `submission` on the submit token was adjusted.