### PR TITLE
Adjust the wrong property name on the submit token (again).

### DIFF
--- a/migrations/Version20230623044735.php
+++ b/migrations/Version20230623044735.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20230622174506 extends AbstractMigration
+final class Version20230623044735 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -22,17 +22,17 @@ final class Version20230622174506 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE submit_token DROP FOREIGN KEY FK_6C047AC8E1FD4933');
         $this->addSql('DROP INDEX UNIQ_6C047AC8E1FD4933 ON submit_token');
-        $this->addSql('ALTER TABLE submit_token CHANGE submission_id valid_submission_id INT DEFAULT NULL');
-        $this->addSql('ALTER TABLE submit_token ADD CONSTRAINT FK_6C047AC86210F1A7 FOREIGN KEY (valid_submission_id) REFERENCES submission (id)');
-        $this->addSql('CREATE UNIQUE INDEX UNIQ_6C047AC86210F1A7 ON submit_token (valid_submission_id)');
+        $this->addSql('ALTER TABLE submit_token CHANGE submission_id last_submission_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE submit_token ADD CONSTRAINT FK_6C047AC88DF22AA4 FOREIGN KEY (last_submission_id) REFERENCES submission (id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_6C047AC88DF22AA4 ON submit_token (last_submission_id)');
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE submit_token DROP FOREIGN KEY FK_6C047AC86210F1A7');
-        $this->addSql('DROP INDEX UNIQ_6C047AC86210F1A7 ON submit_token');
-        $this->addSql('ALTER TABLE submit_token CHANGE valid_submission_id submission_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE submit_token DROP FOREIGN KEY FK_6C047AC88DF22AA4');
+        $this->addSql('DROP INDEX UNIQ_6C047AC88DF22AA4 ON submit_token');
+        $this->addSql('ALTER TABLE submit_token CHANGE last_submission_id submission_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE submit_token ADD CONSTRAINT FK_6C047AC8E1FD4933 FOREIGN KEY (submission_id) REFERENCES submission (id)');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_6C047AC8E1FD4933 ON submit_token (submission_id)');
     }

--- a/src/Controller/Api/V1/Verification/VerificationApiController.php
+++ b/src/Controller/Api/V1/Verification/VerificationApiController.php
@@ -56,7 +56,7 @@ class VerificationApiController extends AbstractController
             return new JsonResponse(['error' => true, 'errorMessage' => 'Submit token not found or not valid.']);
         }
 
-        $submission = $submitToken->getValidSubmission();
+        $submission = $submitToken->getLastSubmission();
         if (!$submission) {
             return new JsonResponse(['error' => true, 'errorMessage' => 'Submission does not exist.']);
         }

--- a/src/Entity/Submission.php
+++ b/src/Entity/Submission.php
@@ -112,13 +112,13 @@ class Submission implements ProjectRelatedEntityInterface
     public function setSubmitToken(?SubmitToken $submitToken): self
     {
         // unset the owning side of the relation if necessary
-        if ($submitToken === null && $this->submitToken !== null && $this->submitToken->getValidSubmission() === $this) {
-            $this->submitToken->setValidSubmission(null);
+        if ($submitToken === null && $this->submitToken !== null && $this->submitToken->getLastSubmission() === $this) {
+            $this->submitToken->setLastSubmission(null);
         }
 
         // set the owning side of the relation if necessary
-        if ($submitToken !== null && $submitToken->getValidSubmission() !== $this) {
-            $submitToken->setValidSubmission($this);
+        if ($submitToken !== null && $submitToken->getLastSubmission() !== $this) {
+            $submitToken->setLastSubmission($this);
         }
 
         $this->submitToken = $submitToken;

--- a/src/Entity/SubmitToken.php
+++ b/src/Entity/SubmitToken.php
@@ -67,7 +67,7 @@ class SubmitToken implements ProjectRelatedEntityInterface
     /**
      * @ORM\OneToOne(targetEntity=Submission::class)
      */
-    private ?Submission $validSubmission;
+    private ?Submission $lastSubmission;
 
     /**
      * @ORM\ManyToOne(targetEntity=Project::class)
@@ -188,14 +188,14 @@ class SubmitToken implements ProjectRelatedEntityInterface
         return $this;
     }
 
-    public function getValidSubmission(): ?Submission
+    public function getLastSubmission(): ?Submission
     {
-        return $this->validSubmission;
+        return $this->lastSubmission;
     }
 
-    public function setValidSubmission(?Submission $validSubmission): self
+    public function setLastSubmission(?Submission $lastSubmission): self
     {
-        $this->validSubmission = $validSubmission;
+        $this->lastSubmission = $lastSubmission;
 
         return $this;
     }

--- a/src/Helper/CleanupHelper.php
+++ b/src/Helper/CleanupHelper.php
@@ -95,7 +95,7 @@ class CleanupHelper
                         $subQb->getDQL()
                     )
                 )
-                ->setParameter('limit', (new DateTime())->sub(new DateInterval('PT1M')))
+                ->setParameter('limit', (new DateTime())->sub(new DateInterval('PT24H')))
                 ->getQuery()->execute();
         }
 


### PR DESCRIPTION
Renamed the `validSubmission` to `lastSubmission`
The initial name, `submission`, was misleading. But the new name `validSubmission` is also misleading because the property contains the last submission and not only the last valid one.

With this pull request, we renamed the property to `lastSubmission`.