### PR TITLE
Add pgsql to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,12 +40,13 @@ RUN apt-get update && \
         zip \
         libzip-dev \
         libpng-dev \
+        libpq-dev \
         unzip \
         autoconf \
         cron \
         wget \
         nginx  && \
-    docker-php-ext-install -j$(nproc) gd intl opcache pdo_mysql zip && \
+    docker-php-ext-install -j$(nproc) gd intl opcache pdo_mysql pdo_pgsql zip && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/docker/Dockerfile.develop
+++ b/docker/Dockerfile.develop
@@ -30,12 +30,13 @@ RUN apt-get update && \
         zip \
         libzip-dev \
         libpng-dev \
+        libpq-dev \
         unzip \
         autoconf \
         cron \
         wget \
         nginx  && \
-    docker-php-ext-install -j$(nproc) gd intl opcache pdo_mysql zip && \
+    docker-php-ext-install -j$(nproc) gd intl opcache pdo_mysql pdo_pgsql zip && \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \


### PR DESCRIPTION
Missing pgsql dependency in docker image:
![Bildschirmfoto vom 2024-06-14 13-41-32](https://github.com/mosparo/mosparo/assets/6280987/9f7fea52-566b-40ec-9a00-eccc62eae9db)

Fix:
![Bildschirmfoto vom 2024-06-14 13-38-58](https://github.com/mosparo/mosparo/assets/6280987/989beffa-d523-4cce-829b-eda2bb032f05)
